### PR TITLE
add Qos setting for fair dispatch

### DIFF
--- a/pubsub/subscriber_rabbitmq.go
+++ b/pubsub/subscriber_rabbitmq.go
@@ -1,11 +1,12 @@
 package pubsub
 
 import (
-	"github.com/febytanzil/gobroker"
-	"github.com/streadway/amqp"
 	"log"
 	"sync/atomic"
 	"time"
+
+	"github.com/febytanzil/gobroker"
+	"github.com/streadway/amqp"
 )
 
 type rabbitMQWorker struct {
@@ -135,6 +136,15 @@ func (r *rabbitMQWorker) initConn(queue, exchange string) error {
 	)
 	if nil != err {
 		log.Panicln("worker could not declare rabbitmq queue", queue, err)
+	}
+
+	err = ch.Qos(
+		1,     // prefetch count
+		0,     // prefetch size
+		false, // global
+	)
+	if nil != err {
+		log.Panicln("worker could not declare rabbitmq Qos", queue, err)
 	}
 
 	err = ch.QueueBind(q.Name, "", exchange, false, nil)

--- a/pubsub/subscriber_rabbitmq.go
+++ b/pubsub/subscriber_rabbitmq.go
@@ -139,7 +139,7 @@ func (r *rabbitMQWorker) initConn(queue, exchange string) error {
 	}
 
 	err = ch.Qos(
-		1,     // prefetch count
+		3,     // prefetch count
 		0,     // prefetch size
 		false, // global
 	)


### PR DESCRIPTION
add Qos setting on consumer
http://www.rabbitmq.com/blog/2012/04/25/rabbitmq-performance-measurements-part-2/
```
To get round-robin behavior between consumers consuming from the same queue on
different connections, set the prefetch count to 1, and the next available
message on the server will be delivered to the next available consumer.

If your consumer work time is reasonably consistent and not much greater
than two times your network round trip time, you will see significant
throughput improvements starting with a prefetch count of 2 or slightly
greater as described by benchmarks on RabbitMQ.
```