### PR TITLE
fix missing cluster name

### DIFF
--- a/pubsub/worker_google.go
+++ b/pubsub/worker_google.go
@@ -38,6 +38,7 @@ func newGoogleWorker(projectID, credFile, cluster string, maxInFlight int) *goog
 		pub: newGooglePub(&config{
 			projectID:      projectID,
 			googleJSONFile: credFile,
+			cluster:        cluster,
 		}),
 		maxOutstanding: maxInFlight,
 		cluster:        cluster,


### PR DESCRIPTION
Fix missing cluster name, when worker trying to initialize publisher